### PR TITLE
Refactor to separate App from OAuth tokens

### DIFF
--- a/views/authorize.erb
+++ b/views/authorize.erb
@@ -3,7 +3,7 @@
   <head>
      <link rel="stylesheet" href="//aui-cdn.atlassian.com/aui-adg/5.9.12/css/aui.min.css" media="all">
      <link rel="stylesheet" href="/css/github-app.css" media="all">
-    <script src="<%= $fqdn %>/atlassian-connect/all.js"></script>
+    <script src="<%= session[:fqdn] %>/atlassian-connect/all.js"></script>
   </head>
    <body>
       <div class="ac-content">

--- a/views/create_branch.erb
+++ b/views/create_branch.erb
@@ -9,7 +9,7 @@
       <div class="ac-content">
         <div class="github-dev-panel">
           <div class="aui-message aui-message-info">
-              <a href="/create_branch">Create a branch in <%= @repo_name %></a></br>
+              <a href="/create_branch">Create a branch in <%= @repo_name[:full_name] %></a></br>
           </div>
           <a href="/logout">clear settings</a>
        </div>

--- a/views/create_branch.erb
+++ b/views/create_branch.erb
@@ -3,7 +3,7 @@
   <head>
      <link rel="stylesheet" href="//aui-cdn.atlassian.com/aui-adg/5.9.12/css/aui.min.css" media="all">
      <link rel="stylesheet" href="/css/github-app.css" media="all">
-    <script src="<%= $fqdn %>/atlassian-connect/all.js"></script>
+    <script src="<%= session[:fqdn] %>/atlassian-connect/all.js"></script>
   </head>
    <body>
       <div class="ac-content">

--- a/views/install_app.erb
+++ b/views/install_app.erb
@@ -3,7 +3,7 @@
   <head>
      <link rel="stylesheet" href="//aui-cdn.atlassian.com/aui-adg/5.9.12/css/aui.min.css" media="all">
      <link rel="stylesheet" href="/css/github-app.css" media="all">
-    <script src="<%= $fqdn %>/atlassian-connect/all.js"></script>
+    <script src="<%= session[:fqdn] %>/atlassian-connect/all.js"></script>
   </head>
    <body>
       <div class="ac-content">

--- a/views/link_to_branch.erb
+++ b/views/link_to_branch.erb
@@ -10,7 +10,7 @@
         <div class="github-dev-panel">
           <div class="aui-message aui-message-info">
             <p class="title">
-              View <a href="https://github.com/<%= session[:repo_name] %>/tree/<%= session[:jira_issue] %>" target="_blank">branch</a> on GitHub
+              View <a href="https://github.com/<%= session[:repo_name][:full_name] %>/tree/<%= session[:jira_issue] %>" target="_blank">branch</a> on GitHub
             </p>
          </div>
          <a href="/logout">clear settings</a>

--- a/views/link_to_branch.erb
+++ b/views/link_to_branch.erb
@@ -3,7 +3,7 @@
   <head>
      <link rel="stylesheet" href="//aui-cdn.atlassian.com/aui-adg/5.9.12/css/aui.min.css" media="all">
      <link rel="stylesheet" href="/css/github-app.css" media="all">
-    <script src="<%= $fqdn %>/atlassian-connect/all.js"></script>
+    <script src="<%= session[:fqdn] %>/atlassian-connect/all.js"></script>
   </head>
    <body>
       <div class="ac-content">

--- a/views/show_repos.erb
+++ b/views/show_repos.erb
@@ -11,7 +11,7 @@
           <p class="title">
             Choose which Repository to create branches in:</br> 
             <% @name_list.each do | val | %>
-              <a href="/add_repo?repo_name=<%= val %>"><%= val %></a></br>
+              <a href="/add_repo?repo_name=<%= val[:full_name] %>"><%= val[:full_name] %></a></br>
             <% end %>
           </p>
           <a href="/logout">clear settings</a>

--- a/views/show_repos.erb
+++ b/views/show_repos.erb
@@ -3,7 +3,7 @@
   <head>
      <link rel="stylesheet" href="//aui-cdn.atlassian.com/aui-adg/5.9.12/css/aui.min.css" media="all">
      <link rel="stylesheet" href="/css/github-app.css" media="all">
-    <script src="<%= $fqdn %>/atlassian-connect/all.js"></script>
+    <script src="<%= session[:fqdn] %>/atlassian-connect/all.js"></script>
   </head>
    <body>
       <div class="ac-content">

--- a/views/thank_you.erb
+++ b/views/thank_you.erb
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
      <link rel="stylesheet" href="//aui-cdn.atlassian.com/aui-adg/5.9.12/css/aui.min.css" media="all">
-    <script src="<%= $fqdn %>/atlassian-connect/all.js"></script>
+    <script src="<%= session[:fqdn] %>/atlassian-connect/all.js"></script>
   </head>
    <body>
       <div class="ac-content">


### PR DESCRIPTION
The previous code assumed there would be a single installation_id - which is incorrect. An OAuth token is required to determine all repositories they have access to and return the list of installation_ids that can access those repositories.

Changes:
- Remove storing an installation_id without context.
- Use Oauth token to determine which repository a user can access
- Store a secure session seed so session variables don't change every server restart. Additionally, remove the insecure - cookie storage 
- Store Repo name along with installation_id in session variables
